### PR TITLE
Fix start screen colors in light mode

### DIFF
--- a/Consolation/Views/ContentViewConnectPanel.swift
+++ b/Consolation/Views/ContentViewConnectPanel.swift
@@ -25,7 +25,7 @@ struct ContentViewConnectPanel: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Device")
                 .font(.title3.weight(.bold))
-                .foregroundStyle(.white)
+                .foregroundStyle(.primary)
             HStack(spacing: 8) {
                 Menu {
                     Section("Video Capture Cards") {
@@ -94,7 +94,7 @@ struct ContentViewConnectPanel: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Resolution")
                     .font(.title3.weight(.bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
                 resolutionMenu(for: device)
                     .disabled(capture.hasNoVideoDevices || isConnecting)
             }
@@ -102,7 +102,7 @@ struct ContentViewConnectPanel: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Resolution")
                     .font(.title3.weight(.bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
                 ConnectPanelPillLabel(value: "—")
                     .opacity(0.45)
                     .allowsHitTesting(false)
@@ -203,21 +203,21 @@ private struct ConnectPanelPillLabel: View {
         HStack(alignment: .center, spacing: 12) {
             Text(value)
                 .font(.title3.weight(.semibold))
-                .foregroundStyle(.white)
+                .foregroundStyle(.primary)
                 .multilineTextAlignment(.leading)
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 4)
             Image(systemName: "chevron.down")
                 .font(.title3.weight(.semibold))
-                .foregroundStyle(.white.opacity(0.8))
+                .foregroundStyle(.secondary)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.white.opacity(0.08), in: Capsule())
+        .background(Color.primary.opacity(0.08), in: Capsule())
         .overlay {
             Capsule()
-                .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
+                .strokeBorder(Color.primary.opacity(0.18), lineWidth: 1)
         }
         .contentShape(Capsule())
     }
@@ -235,7 +235,7 @@ private struct CaptureDeviceCompatibilityIssueView: View {
                     .font(.title)
                 Text("Capture Card Compatibility")
                     .font(.title.weight(.semibold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
             }
             .padding(.vertical, 16)
 

--- a/Consolation/Views/ContentViewHeaderUtilityButton.swift
+++ b/Consolation/Views/ContentViewHeaderUtilityButton.swift
@@ -26,14 +26,14 @@ struct ContentViewHeaderUtilityButton: View {
             Label(title, systemImage: systemImage)
                 .font(.system(size: 13, weight: .semibold))
                 .labelStyle(.titleAndIcon)
-                .foregroundStyle(.white.opacity(0.88))
+                .foregroundStyle(Color.primary.opacity(0.88))
                 .padding(.horizontal, 10)
                 .padding(.vertical, 7)
-                .background(Color.white.opacity(0.08), in: Capsule())
+                .background(Color.primary.opacity(0.08), in: Capsule())
                 .overlay {
                     Capsule()
                         .strokeBorder(
-                            Color.white.opacity(isHovered ? 1 : 0.16),
+                            Color.primary.opacity(isHovered ? 1 : 0.16),
                             lineWidth: 1
                         )
                 }

--- a/Consolation/Views/ContentViewStartScreen.swift
+++ b/Consolation/Views/ContentViewStartScreen.swift
@@ -44,11 +44,11 @@ struct ContentViewStartScreen: View {
             HStack(alignment: .lastTextBaseline, spacing: 6) {
                 Text(AppIdentifier.name)
                     .font(.system(size: 36, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.primary)
 
                 Text("v" + BuildInfo.version)
                     .font(.system(size: 16))
-                    .foregroundStyle(.white.opacity(0.7))
+                    .foregroundStyle(.secondary)
             }
             .multilineTextAlignment(.center)
         }

--- a/Consolation/Views/ContentViewStartWatchingButton.swift
+++ b/Consolation/Views/ContentViewStartWatchingButton.swift
@@ -15,16 +15,16 @@ struct ContentViewStartWatchingButton: View {
         } label: {
             ZStack {
                 Circle()
-                    .fill(Color.white.opacity(0.16))
+                    .fill(Color.primary.opacity(0.16))
                 Image(systemName: "play.fill")
                     .font(.system(size: 36, weight: .semibold))
-                    .foregroundStyle(Color.white)
+                    .foregroundStyle(Color.primary)
                     .allowsHitTesting(false)
             }
             .overlay {
                 if isHovered {
                     Circle()
-                        .strokeBorder(Color.white.opacity(0.88), lineWidth: 1)
+                        .strokeBorder(Color.primary.opacity(0.88), lineWidth: 1)
                 }
             }
             .frame(width: 72, height: 72)


### PR DESCRIPTION
## Summary

- replace hard-coded white foreground styles on the start screen with SwiftUI semantic colors
- make the device and resolution pills, start button, and utility buttons adapt to the active appearance
- keep fixed white styling for playback controls and video overlays, where the content remains on a dark or video background

## Problem

The start screen's material and Liquid Glass appearance adapt between light and dark mode, but its foreground colors were hard-coded to white. In light mode this produced low-contrast text and controls on the lighter panel.

Using `.primary`, `.secondary`, and `Color.primary.opacity(...)` allows the foreground and control chrome to follow the system appearance together with the panel.

## Validation

- `xcodebuild -project Consolation.xcodeproj -scheme Consolation -configuration Release -destination 'platform=macOS' ... build` (`BUILD SUCCEEDED`)
- `git diff --check`
- manually verified the generated macOS app in both light and dark mode
